### PR TITLE
Updated for Groovy 4

### DIFF
--- a/createDerby.groovy
+++ b/createDerby.groovy
@@ -2,7 +2,8 @@
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import groovy.util.slurpersupport.NodeChildren;
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.NodeChildren;
 
 import org.bridgedb.IDMapperException;
 import org.bridgedb.DataSource;


### PR DESCRIPTION
Jenkins now uses the latest Groovy version, which moved the XmlSlurper to a new package. This should fix the compile issue on Jenkins.